### PR TITLE
feat: add label prop and polish text style for radio component

### DIFF
--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -8,20 +8,21 @@ export interface RadioProps
     React.InputHTMLAttributes<HTMLInputElement>,
     'type' | 'children' | 'size'
   > {
+  label?: React.ReactNode;
   size?: RadioSize;
   children?: React.ReactNode;
 }
 
 export function Radio({
-  children,
+  label,
   size = 'default',
   className,
   disabled,
   checked,
+  children,
   ...props
 }: RadioProps) {
   const id = useId();
-
   const sizeClass = {
     sm: {
       wrapper: 'h-3.5 w-3.5',
@@ -41,8 +42,8 @@ export function Radio({
     <label
       htmlFor={id}
       className={clsx(
-        'inline-flex items-center gap-2 select-none',
-        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+        'inline-flex items-center gap-1 cursor-pointer select-none',
+        disabled && 'opacity-50 cursor-not-allowed',
         className,
       )}
     >
@@ -77,7 +78,11 @@ export function Radio({
           />
         </span>
       </span>
-      {children && <span className="dark:text-zinc-100">{children}</span>}
+      {(label || children) && (
+        <span className="text-sm font-medium tracking-tight text-zinc-900 dark:text-zinc-100">
+          {label || children}
+        </span>
+      )}
     </label>
   );
 }


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Change type:

- 🎨 Refactor / Style polish
- 📦 Other (please describe below)
  - Added a new `label` prop to the `<Radio>` component to simplify label rendering
  - Updated layout to align text vertically with the radio circle for better visual consistency
  - Reduced the spacing between the radio icon and its label text
  - Ensured style consistency with `<Checkbox>` component

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->
- Verified the `label` prop renders correctly alongside the radio input
- Checked visual alignment of text and icon across different label lengths
- Ensured reduced spacing doesn’t affect readability or click area
- Compared with `<Checkbox>` to ensure consistent look and feel
- Confirmed label-click behavior still focuses/selects the radio input
- Manually tested in both light and dark themes

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
