### PR TITLE
fix: mask component is not scrollable

### DIFF
--- a/src/mask/mask.tsx
+++ b/src/mask/mask.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import { Button } from '../button';
@@ -22,27 +22,38 @@ export function Mask({
   closable = true,
   onClose,
 }: MaskProps) {
+  useEffect(() => {
+    if (open) document.body.classList.add('overflow-hidden');
+    else document.body.classList.remove('overflow-hidden');
+    return () => document.body.classList.remove('overflow-hidden');
+  }, [open]);
+
   if (!open || typeof window === 'undefined') return null;
 
   return createPortal(
     <div
       className={clsx(
-        'fixed inset-0 flex items-center justify-center transition-opacity duration-300 backdrop-blur-sm',
+        'fixed inset-0 overflow-y-auto transition-opacity duration-300 backdrop-blur-sm',
         'bg-white dark:bg-zinc-900',
-        open ? 'opacity-100' : 'opacity-0 pointer-events-none',
+        open ? '' : 'pointer-events-none',
       )}
-      style={{ zIndex, opacity: open ? opacity / 100 : 0 }}
+      style={{
+        zIndex,
+        opacity: open ? opacity / 100 : 0,
+      }}
     >
-      {closable && (
-        <Button
-          icon={<Close />}
-          onClick={onClose}
-          size="sm"
-          variant="link"
-          className="absolute top-4 right-4"
-        />
-      )}
-      {children}
+      <div className="relative min-h-screen flex items-center justify-center px-4 py-12">
+        {closable && (
+          <Button
+            icon={<Close />}
+            onClick={onClose}
+            size="sm"
+            variant="link"
+            className="absolute top-4 right-4"
+          />
+        )}
+        {children}
+      </div>
     </div>,
     document.body,
   );


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Change type:

- 🐛 Bugfix

### Description
This PR fixes two issues with the Mask component:

1. **Mask content was clipped when exceeding the viewport height**
→ Replaced `flex items-center justify-center` layout with `overflow-y-auto` and `min-h-screen` to ensure content is scrollable when tall.

2. **Page scrolling was still possible while the Mask was open**
→ → Applied `overflow-hidden` to the `<body>` element dynamically when `Mask` is open, preventing background scroll behavior. This was done imperatively inside the `Mask` component, not via a custom hook.
---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

Tested in Storybook by:

- Opening the `Mask` with very tall content — content is now scrollable.
- Ensuring that while the `Mask` is open, the background page does not scroll.
- Verified cleanup when `Mask` closes (body scroll is restored).

<img width="2814" height="1894" alt="30665ae0-e38d-4aa4-9591-8b5aefd8d863" src="https://github.com/user-attachments/assets/a9ee4942-f25e-488f-b3f4-f647445acf59" />


## 📎 Related Issues

<!-- Link to related issues or discussions -->

Closes #14 

---

Thanks for your contribution 🙌
