### PR TITLE
feat(button): add danger prop to apply red color

### DIFF
--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -45,23 +45,6 @@ export const Default: Story = {
   },
 };
 
-export const Variants: Story = {
-  render: (args) => (
-    <div className="flex flex-wrap gap-4">
-      <Button {...args}>Primary</Button>
-      <Button {...args} variant="outline">
-        Outline
-      </Button>
-      <Button {...args} variant="dashed">
-        Outline
-      </Button>
-      <Button {...args} variant="link">
-        Link
-      </Button>
-    </div>
-  ),
-};
-
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex flex-wrap gap-4 items-center">
@@ -78,6 +61,23 @@ export const Sizes: Story = {
   ),
 };
 
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-4">
+      <Button {...args}>Primary</Button>
+      <Button {...args} variant="outline">
+        Outline
+      </Button>
+      <Button {...args} variant="dashed">
+        Dashed
+      </Button>
+      <Button {...args} variant="link">
+        Link
+      </Button>
+    </div>
+  ),
+};
+
 export const DisabledStates: Story = {
   args: { disabled: true },
   render: (args) => (
@@ -85,6 +85,27 @@ export const DisabledStates: Story = {
       <Button {...args}>Primary</Button>
       <Button {...args} variant="outline">
         Outline
+      </Button>
+      <Button {...args} variant="dashed">
+        Dashed
+      </Button>
+      <Button {...args} variant="link">
+        Link
+      </Button>
+    </div>
+  ),
+};
+
+export const DangerStates: Story = {
+  args: { danger: true },
+  render: (args) => (
+    <div className="flex flex-wrap gap-4">
+      <Button {...args}>Primary</Button>
+      <Button {...args} variant="outline">
+        Outline
+      </Button>
+      <Button {...args} variant="dashed">
+        Dashed
       </Button>
       <Button {...args} variant="link">
         Link
@@ -135,7 +156,25 @@ export const LoadingStates: Story = {
         <Button {...args} variant="outline">
           Outline
         </Button>
+        <Button {...args} variant="dashed">
+          Outline
+        </Button>
         <Button {...args} variant="link">
+          Link
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <Button {...args} danger>
+          Primary
+        </Button>
+        <Button {...args} variant="outline" danger>
+          Outline
+        </Button>
+        <Button {...args} variant="dashed" danger>
+          Dashed
+        </Button>
+        <Button {...args} variant="link" danger>
           Link
         </Button>
       </div>

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import { Spinner } from '../spinner';
 
@@ -12,6 +11,7 @@ export interface ButtonProps
   size?: ButtonSize;
   icon?: React.ReactNode;
   loading?: boolean;
+  danger?: boolean;
 }
 
 export function Button({
@@ -20,6 +20,7 @@ export function Button({
   disabled,
   icon,
   loading = false,
+  danger = false,
   className,
   children,
   ...props
@@ -29,30 +30,36 @@ export function Button({
 
   const variantClass = {
     primary: clsx(
-      'text-white bg-zinc-900 hover:bg-zinc-600 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300',
-      'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-900 dark:focus:ring-zinc-100',
-      disabled &&
-        'bg-zinc-400 text-white hover:bg-zinc-400 dark:bg-zinc-500 dark:text-white',
+      'text-white',
+      disabled
+        ? 'bg-zinc-400 hover:bg-zinc-400'
+        : danger
+          ? 'bg-red-500 hover:bg-red-600'
+          : 'bg-zinc-900 hover:bg-zinc-600 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300',
     ),
     outline: clsx(
-      'border border-zinc-900 text-zinc-900 hover:bg-zinc-900 hover:text-white',
-      'dark:border-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900',
-      'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-900 dark:focus:ring-zinc-100',
-      disabled &&
-        'border-zinc-300 text-zinc-300 hover:bg-transparent hover:text-zinc-300 dark:border-zinc-600 dark:text-zinc-600 dark:hover:text-zinc-600',
+      'border',
+      disabled
+        ? 'border-zinc-400 text-zinc-400'
+        : danger
+          ? 'border-red-500 text-red-500 hover:bg-red-50 dark:hover:bg-red-900'
+          : 'border-zinc-900 text-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900',
     ),
     dashed: clsx(
-      'border border-dashed border-zinc-900 text-zinc-900 hover:bg-zinc-100',
-      'dark:border-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-900 dark:hover:text-white',
-      'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-900 dark:focus:ring-zinc-100',
-      disabled &&
-        'border-zinc-300 text-zinc-300 dark:border-zinc-600 dark:text-zinc-600',
+      'border border-dashed',
+      disabled
+        ? 'border-zinc-400 text-zinc-400'
+        : danger
+          ? 'border-red-500 text-red-500 hover:bg-red-50 dark:hover:bg-red-900'
+          : 'border-zinc-900 text-zinc-900 hover:bg-zinc-100 dark:border-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-700',
     ),
     link: clsx(
-      'text-zinc-900 underline-offset-4 hover:underline hover:text-zinc-600',
-      'dark:text-zinc-100 dark:hover:text-zinc-300',
-      disabled &&
-        'text-zinc-400 hover:text-zinc-400 dark:text-zinc-500 dark:hover:text-zinc-500',
+      'underline-offset-4',
+      disabled
+        ? 'text-zinc-500 hover:text-zinc-600'
+        : danger
+          ? 'text-red-500 hover:underline hover:text-red-600'
+          : 'text-zinc-900 hover:underline hover:text-zinc-600 dark:text-zinc-100 dark:hover:text-zinc-300',
     ),
   }[variant];
 


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- ✨ Enhanced `Button` component with `danger` prop to support red-tone styling across variants.
- 🎨 Simplified `disabled` state styling — unified styles regardless of `danger` status.
- 🎨 Polished `clsx` logic structure for clearer variant and state management.
- ⚡ This update ensures consistent disabled behavior and cleaner conditional class handling.

Change type:

- ✨ New Feature
- 🎨 Refactor / Style polish

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook across all `variant` types (`primary`, `outline`, `dashed`, `link`).
- Tested combinations of `danger`, `disabled`, `loading`, and `icon` props.
- Confirmed visual consistency in light/dark mode.

<img width="1566" height="364" alt="image" src="https://github.com/user-attachments/assets/867e0015-5a40-485d-b6f7-4bd097ac78a0" />
<img width="1572" height="394" alt="image" src="https://github.com/user-attachments/assets/bdd37039-1872-45e2-af02-8cf0b8a240c5" />


## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
