### PR TITLE
feat(button): add 'xs' size option to button

### DIFF
--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -48,6 +48,9 @@ export const Default: Story = {
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex flex-wrap gap-4 items-center">
+      <Button {...args} size="xs">
+        XS
+      </Button>
       <Button {...args} size="sm">
         Small
       </Button>
@@ -138,6 +141,9 @@ export const LoadingStates: Story = {
   render: (args) => (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-4">
+        <Button {...args} size="xs">
+          XS
+        </Button>
         <Button {...args} size="sm">
           Small
         </Button>
@@ -180,6 +186,8 @@ export const LoadingStates: Story = {
       </div>
 
       <div className="flex items-center gap-4">
+        <Button {...args} size="xs" icon={<AiFillNotification />} />
+        <Button {...args} size="sm" icon={<AiFillNotification />} />
         <Button {...args} size="default" icon={<AiFillNotification />} />
         <Button {...args} size="lg" icon={<AiFillNotification />} />
       </div>

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { Spinner } from '../spinner';
 
 export type ButtonVariant = 'primary' | 'outline' | 'link' | 'dashed';
-export type ButtonSize = 'sm' | 'default' | 'lg';
+export type ButtonSize = 'xs' | 'sm' | 'default' | 'lg';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -67,19 +67,24 @@ export function Button({
 
   const sizeClass = isIconOnly
     ? {
+        xs: 'w-6 h-6 text-xs',
         sm: 'w-8 h-8 text-sm',
         default: 'w-10 h-10 text-base',
         lg: 'w-12 h-12 text-lg',
       }[size]
     : {
+        xs: 'text-xs px-2 py-1',
         sm: 'text-sm px-3 py-1.5',
         default: 'text-base px-4 py-2',
         lg: 'text-lg px-5 py-2.5',
       }[size];
 
-  const iconSizeClass = { sm: 'w-4 h-4', default: 'w-5 h-5', lg: 'w-6 h-6' }[
-    size
-  ];
+  const iconSizeClass = {
+    xs: 'w-3 h-3',
+    sm: 'w-4 h-4',
+    default: 'w-5 h-5',
+    lg: 'w-6 h-6',
+  }[size];
 
   return (
     <button


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Added `xs` size option to the `Button` component to support smaller button variants.
This includes:

- Extending `ButtonSize` type with `xs`.
- Defining `xs` sizeClass with smaller padding and text size.
- Adjusted icon sizing for `xs` buttons.
- Ensured style consistency across all variants (primary, outline, dashed, link).

Change type:

✨ New Feature (Component Enhancement)

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Checked icon-only buttons with `xs` size align and size correctly.
- Manually inspected responsiveness and spacing for `xs` buttons in both light and dark themes.
- Confirmed backward compatibility with existing `sm`, `default`, and `lg` sizes.

<img width="918" height="244" alt="image" src="https://github.com/user-attachments/assets/0b64f2fa-d674-4993-abf2-1bdff573b8d3" />

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
