### PR TITLE
feat(popconfirm): add PopConfirm component with arrow placement support

### DIFF
--- a/src/arrow.tsx
+++ b/src/arrow.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+
+export type ArrowPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface ArrowProps {
+  placement?: ArrowPlacement;
+  size?: number;
+  className?: string;
+}
+
+export function Arrow({ placement = 'top', size = 6, className }: ArrowProps) {
+  const rotation = {
+    top: 'rotate-180',
+    bottom: '',
+    left: 'rotate-90',
+    right: '-rotate-90',
+  }[placement];
+
+  const positionClass = {
+    top: 'top-full left-1/2 -translate-x-1/2',
+    bottom: 'bottom-full left-1/2 -translate-x-1/2',
+    left: 'left-full top-1/2 -translate-y-1/2 -translate-x-1/4',
+    right: 'right-full top-1/2 -translate-y-1/2 translate-x-1/4',
+  }[placement];
+
+  return (
+    <div
+      className={clsx('absolute', rotation, positionClass, className)}
+      style={{
+        width: size * 2,
+        height: size,
+        clipPath: 'polygon(50% 0%, 0% 100%, 100% 100%)',
+      }}
+    />
+  );
+}

--- a/src/pop-confirm/index.ts
+++ b/src/pop-confirm/index.ts
@@ -1,0 +1,1 @@
+export * from './pop-confirm';

--- a/src/pop-confirm/pop-confirm.stories.tsx
+++ b/src/pop-confirm/pop-confirm.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '../button';
+
+import { PopConfirm } from './pop-confirm';
+
+const meta: Meta<typeof PopConfirm> = {
+  title: 'Components/PopConfirm',
+  component: PopConfirm,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A confirmation popover that prompts user for confirmation before taking an action.',
+      },
+    },
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    confirmText: { control: 'text' },
+    cancelText: { control: 'text' },
+    onConfirm: { action: 'confirmed' },
+    onCancel: { action: 'cancelled' },
+  },
+  args: {
+    title: 'Are you sure?',
+    description: 'This action cannot be undone.',
+    confirmText: 'Yes',
+    cancelText: 'No',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <PopConfirm {...args}>
+      <Button danger>Delete</Button>
+    </PopConfirm>
+  ),
+};
+
+export const Placement: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-8 items-center justify-center">
+      <PopConfirm {...args} placement="top">
+        <Button danger>Top</Button>
+      </PopConfirm>
+      <PopConfirm {...args} placement="right">
+        <Button danger>Right</Button>
+      </PopConfirm>
+      <PopConfirm {...args} placement="bottom">
+        <Button danger>Bottom</Button>
+      </PopConfirm>
+      <PopConfirm {...args} placement="left">
+        <Button danger>Left</Button>
+      </PopConfirm>
+    </div>
+  ),
+};
+
+export const WithoutDescription: Story = {
+  render: (args) => (
+    <PopConfirm {...args} description={undefined}>
+      <Button variant="outline" danger>
+        Archive
+      </Button>
+    </PopConfirm>
+  ),
+};

--- a/src/pop-confirm/pop-confirm.tsx
+++ b/src/pop-confirm/pop-confirm.tsx
@@ -1,0 +1,108 @@
+import clsx from 'clsx';
+import React, { useState, useRef, useEffect } from 'react';
+
+import { Arrow } from '../arrow';
+import { Button } from '../button';
+
+export type PopConfirmPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface PopConfirmProps {
+  children: React.ReactElement;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  placement?: PopConfirmPlacement;
+}
+
+export function PopConfirm({
+  children,
+  title,
+  description,
+  confirmText = 'Yes',
+  cancelText = 'No',
+  onConfirm,
+  onCancel,
+  placement = 'top',
+}: PopConfirmProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const getPlacementClass = () => {
+    switch (placement) {
+      case 'top':
+        return 'left-1/2 bottom-full -translate-x-1/2 mb-2';
+      case 'bottom':
+        return 'left-1/2 top-full -translate-x-1/2 mt-2';
+      case 'left':
+        return 'right-full top-1/2 -translate-y-1/2 mr-2';
+      case 'right':
+        return 'left-full top-1/2 -translate-y-1/2 ml-2';
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      {React.cloneElement(children, {
+        onClick: () => setOpen((prev) => !prev),
+      })}
+      {open && (
+        <div
+          className={clsx(
+            'absolute z-50 w-64 p-4 rounded-md bg-white dark:bg-zinc-900 border border-zinc-500',
+            getPlacementClass(),
+          )}
+        >
+          <Arrow placement={placement} className="bg-zinc-500" />
+          <div className="font-medium text-zinc-900 dark:text-zinc-100">
+            {title}
+          </div>
+          {description && (
+            <div className="mt-1 text-zinc-600 dark:text-zinc-400 text-sm">
+              {description}
+            </div>
+          )}
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => {
+                onCancel?.();
+                setOpen(false);
+              }}
+            >
+              {cancelText}
+            </Button>
+            <Button
+              size="xs"
+              onClick={() => {
+                onConfirm();
+                setOpen(false);
+              }}
+            >
+              {confirmText}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Add `PopConfirm` component to confirm user actions before proceeding.
- Supports customizable title, description, confirm/cancel texts.
- Arrow placement supports `top`, `bottom`, `left`, `right` with seamless border rendering.
- Fully responsive to light/dark modes.

Change type:

- ✨ New Component

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook across all placement directions.
- Tested in both light and dark modes.
- Confirm/Cancel actions trigger callbacks correctly.
- Arrow and card borders are visually integrated without gaps or misalignments.

<img width="1784" height="742" alt="image" src="https://github.com/user-attachments/assets/e7168357-36f7-4564-931b-95dca4acc1d7" />

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
