### PR TITLE
refactor(tooltip): use arrow to replace tooltip arrow

### DIFF
--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
 
+import { Arrow } from '../arrow';
+
 export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
 
 export interface TooltipProps {
@@ -33,18 +35,6 @@ export function Tooltip({
   };
 
   const bgClass = 'bg-zinc-700 dark:bg-zinc-500 text-white';
-  const arrowLight = '#3f3f46';
-  const arrowDark = '#71717b';
-
-  const getArrowColor = () => {
-    if (
-      typeof window !== 'undefined' &&
-      document.documentElement.classList.contains('dark')
-    ) {
-      return arrowDark;
-    }
-    return arrowLight;
-  };
 
   const getPositionClass = () => {
     switch (placement) {
@@ -59,67 +49,6 @@ export function Tooltip({
       default:
         return '';
     }
-  };
-
-  const Arrow = () => {
-    const color = getArrowColor();
-    if (placement === 'top') {
-      return (
-        <span
-          className="absolute left-1/2 top-full -translate-x-1/2"
-          style={{
-            width: 0,
-            height: 0,
-            borderLeft: '6px solid transparent',
-            borderRight: '6px solid transparent',
-            borderTop: `6px solid ${color}`,
-          }}
-        />
-      );
-    }
-    if (placement === 'bottom') {
-      return (
-        <span
-          className="absolute left-1/2 bottom-full -translate-x-1/2"
-          style={{
-            width: 0,
-            height: 0,
-            borderLeft: '6px solid transparent',
-            borderRight: '6px solid transparent',
-            borderBottom: `6px solid ${color}`,
-          }}
-        />
-      );
-    }
-    if (placement === 'left') {
-      return (
-        <span
-          className="absolute top-1/2 left-full -translate-y-1/2"
-          style={{
-            width: 0,
-            height: 0,
-            borderTop: '6px solid transparent',
-            borderBottom: '6px solid transparent',
-            borderLeft: `6px solid ${color}`,
-          }}
-        />
-      );
-    }
-    if (placement === 'right') {
-      return (
-        <span
-          className="absolute top-1/2 right-full -translate-y-1/2"
-          style={{
-            width: 0,
-            height: 0,
-            borderTop: '6px solid transparent',
-            borderBottom: '6px solid transparent',
-            borderRight: `6px solid ${color}`,
-          }}
-        />
-      );
-    }
-    return null;
   };
 
   const child = React.cloneElement(children, {
@@ -166,8 +95,8 @@ export function Tooltip({
           role="tooltip"
           aria-hidden={!visible}
         >
+          <Arrow placement={placement} className={clsx(bgClass)} />
           {content}
-          <Arrow />
         </span>
       )}
     </span>


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

This PR refactors the `Tooltip` component to use the newly created shared `Arrow` component, which is now also used by `PopConfirm`. By consolidating the arrow rendering logic into a reusable component, we ensure consistent appearance, positioning logic, and easier future maintenance across components that require arrow indicators.

Key Changes:

- Removed inline/custom arrow rendering logic from `Tooltip`.
- Integrated the shared `Arrow` component in `Tooltip`, aligning with `PopConfirm`.
- Simplified `Tooltip` styles and positioning calculation related to arrow alignment.
- Minor clean-up of redundant code.

Change type:

🎨 Refactor / Component Reuse

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified `Tooltip` arrow rendering correctly in all placement variants (`top`, `bottom`, `left`, `right`) through Storybook.
- Checked `PopConfirm` to ensure arrow behavior remains intact.
- Tested hover/focus-triggered tooltips with arrow alignment in various container contexts.
- Performed visual regression comparison to ensure no layout shifts or style discrepancies were introduced.

## 📎 Related Issues

<!-- Link to related issues or discussions -->

#22 

---

Thanks for your contribution 🙌
