### PR TITLE
refactor(badge): remove icon prop

### DIFF
--- a/src/badge/badge.stories.tsx
+++ b/src/badge/badge.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { AiFillNotification } from 'react-icons/ai';
+
+import { Bell } from '../icons';
 
 import { Badge } from './badge';
 
@@ -34,7 +35,6 @@ const meta: Meta<typeof Badge> = {
       control: 'radio',
       options: ['sm', 'default', 'lg'],
     },
-    icon: { control: false },
   },
 };
 
@@ -58,6 +58,10 @@ export const Variants: Story = {
       </Badge>
       <Badge {...args} variant="soft">
         Soft
+      </Badge>
+      <Badge {...args}>
+        <Bell size={18} />
+        <span className="ml-1">With Icon</span>
       </Badge>
     </div>
   ),
@@ -93,33 +97,6 @@ export const Sizes: Story = {
       </Badge>
       <Badge {...args} size="lg">
         Large
-      </Badge>
-    </div>
-  ),
-};
-
-export const WithIcon: Story = {
-  render: (args) => (
-    <div className="flex flex-wrap gap-4 items-center">
-      <Badge {...args} icon={<AiFillNotification />} />
-      <Badge {...args} icon={<AiFillNotification />}>
-        With Text
-      </Badge>
-      <Badge
-        {...args}
-        color="success"
-        variant="outline"
-        icon={<AiFillNotification />}
-      >
-        Success
-      </Badge>
-      <Badge
-        {...args}
-        color="danger"
-        variant="soft"
-        icon={<AiFillNotification />}
-      >
-        Danger
       </Badge>
     </div>
   ),

--- a/src/badge/badge.tsx
+++ b/src/badge/badge.tsx
@@ -9,7 +9,6 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;
   color?: BadgeColor;
   size?: BadgeSize;
-  icon?: React.ReactNode;
 }
 
 const colorMap = {
@@ -49,7 +48,6 @@ export function Badge({
   variant = 'solid',
   color = 'default',
   size = 'default',
-  icon,
   className,
   children,
   ...props
@@ -64,7 +62,6 @@ export function Badge({
       )}
       {...props}
     >
-      {icon && <span className="mr-1.5">{icon}</span>}
       {children}
     </span>
   );


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Removed the `icon` prop from the `Badge` component
- Recommended passing icons through `children` instead for more flexible layout and style control
- Updated documentation and Storybook examples to remove icon usage
- Cleaned up unused type definitions and related style code

Change type:

- 🎨 Refactor / Style polish
- 📝 Docs update

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook that `Badge` renders correctly with and without icons
- Confirmed that removing the `icon` prop does not affect other props’ behavior or styling
- Ran component tests to ensure no regressions beyond the expected snapshot changes

## 📎 Related Issues

<!-- Link to related issues or discussions -->

#28 

---

Thanks for your contribution 🙌
