### PR TITLE
refactor(callout): remove icon prop

### DIFF
--- a/src/callout/callout.stories.tsx
+++ b/src/callout/callout.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { AiOutlineInfoCircle } from 'react-icons/ai';
 
 import { Button } from '../button';
+import { Info } from '../icons';
 
 import { Callout } from './callout';
 
@@ -43,11 +43,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => (
-    <Callout
-      {...args}
-      icon={<AiOutlineInfoCircle className="w-5 h-5 text-zinc-600" />}
-    >
-      This is a basic callout.
+    <Callout {...args}>
+      <span className="flex items-center gap-1">
+        <Info size={20} />
+        This is a basic callout.
+      </span>
     </Callout>
   ),
 };
@@ -55,19 +55,24 @@ export const Default: Story = {
 export const Variants: Story = {
   render: (args) => (
     <div className="flex flex-col gap-4">
-      <Callout {...args} variant="primary" icon={<span>ℹ️</span>}>
+      <Callout {...args} variant="primary">
+        <span className="mr-1.5">ℹ️</span>
         Primary variant
       </Callout>
-      <Callout {...args} variant="outline" icon={<span>📦</span>}>
+      <Callout {...args} variant="outline">
+        <span className="mr-1.5">📦</span>
         Outline variant
       </Callout>
-      <Callout {...args} variant="danger" icon={<span>❌</span>}>
+      <Callout {...args} variant="danger">
+        <span className="mr-1.5">❌</span>
         Danger variant
       </Callout>
-      <Callout {...args} variant="warning" icon={<span>⚠️</span>}>
+      <Callout {...args} variant="warning">
+        <span className="mr-1.5">⚠️</span>
         Warning variant
       </Callout>
-      <Callout {...args} variant="success" icon={<span>✅</span>}>
+      <Callout {...args} variant="success">
+        <span className="mr-1.5">✅</span>
         Success variant
       </Callout>
     </div>
@@ -77,13 +82,16 @@ export const Variants: Story = {
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex flex-col gap-4">
-      <Callout {...args} size="sm" icon={<span>🔹</span>}>
+      <Callout {...args} size="sm">
+        <span className="mr-1.5">🔹</span>
         Small size
       </Callout>
-      <Callout {...args} size="default" icon={<span>🔸</span>}>
+      <Callout {...args} size="default">
+        <span className="mr-1.5">🔸</span>
         Default size
       </Callout>
-      <Callout {...args} size="lg" icon={<span>🔷</span>}>
+      <Callout {...args} size="lg">
+        <span className="mr-1.5">🔷</span>
         Large size
       </Callout>
     </div>
@@ -94,13 +102,11 @@ export const Closable: Story = {
   render: (args) => {
     const [open, setOpen] = useState(true);
     return open ? (
-      <Callout
-        {...args}
-        closable
-        onClose={() => setOpen(false)}
-        icon={<AiOutlineInfoCircle className="w-5 h-5 text-zinc-600" />}
-      >
-        This callout can be closed by clicking ×.
+      <Callout {...args} closable onClose={() => setOpen(false)}>
+        <span className="flex items-center gap-1">
+          <Info size={20} />
+          This callout can be closed by clicking ×.
+        </span>
       </Callout>
     ) : (
       <Button variant="link" onClick={() => setOpen(true)}>

--- a/src/callout/callout.tsx
+++ b/src/callout/callout.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 
 import { Button } from '../button';
+import { Close } from '../icons';
 
 export type CalloutVariant =
   | 'primary'
@@ -15,7 +16,6 @@ export interface CalloutProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: CalloutSize;
   closable?: boolean;
   onClose?: () => void;
-  icon?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -24,7 +24,6 @@ export function Callout({
   size = 'default',
   closable = false,
   onClose,
-  icon,
   className,
   children,
   ...props
@@ -50,25 +49,18 @@ export function Callout({
     lg: 'text-lg px-5 py-4',
   }[size];
 
-  const iconClass = 'flex items-center text-zinc-400 dark:text-zinc-400';
-
-  const closeClass =
-    'ml-2 text-zinc-400 hover:text-zinc-200 dark:text-zinc-400 dark:hover:text-white rounded-md text-lg font-bold leading-none transition-colors cursor-pointer';
-
   return (
     <div className={clsx(base, variantClass, sizeClass, className)} {...props}>
-      {icon && <span className={iconClass}>{icon}</span>}
-      <span className="flex-1 ml-2">{children}</span>
+      <span className="flex-1">{children}</span>
       {closable && (
         <Button
+          icon={<Close />}
+          size="xs"
           variant="link"
           type="button"
           aria-label="Close"
-          className={closeClass}
           onClick={onClose}
-        >
-          ×
-        </Button>
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Removed the `icon` prop from the `Callout` component
- Recommended passing icons through `children` instead for more flexible layout and style control
- Use icon `Close` to replace original `x`
- Updated documentation and Storybook examples to remove icon usage
- Cleaned up unused type definitions and related style code

Change type:

- 🎨 Refactor / Style polish
- 📝 Docs update

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook that `Callout` renders correctly with and without icons
- Verified in Storybook that `Callout` renders correctly close icon
- Confirmed that removing the `icon` prop does not affect other props’ behavior or styling
- Ran component tests to ensure no regressions beyond the expected snapshot changes

## 📎 Related Issues

<!-- Link to related issues or discussions -->

#28 

---

Thanks for your contribution 🙌
