### PR TITLE
refactor: remove react-icons from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "prettier": "^3.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0",
     "rollup-plugin-visualizer": "^6.0.3",
     "storybook": "^9.0.13",
     "tailwindcss": "^4.1.3",

--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { AiFillNotification } from 'react-icons/ai';
+
+import { Message } from '../icons';
 
 import { Button } from './button';
 
@@ -120,16 +121,16 @@ export const DangerStates: Story = {
 export const WithIcon: Story = {
   render: (args) => (
     <div className="flex flex-wrap gap-4 items-center">
-      <Button {...args} icon={<AiFillNotification />} />
-      <Button {...args} variant="outline" icon={<AiFillNotification />} />
-      <Button {...args} variant="link" icon={<AiFillNotification />} />
-      <Button {...args} icon={<AiFillNotification />}>
+      <Button {...args} icon={<Message />} />
+      <Button {...args} variant="outline" icon={<Message />} />
+      <Button {...args} variant="link" icon={<Message />} />
+      <Button {...args} icon={<Message />}>
         With Text
       </Button>
-      <Button {...args} variant="outline" icon={<AiFillNotification />}>
+      <Button {...args} variant="outline" icon={<Message />}>
         With Text
       </Button>
-      <Button {...args} variant="link" icon={<AiFillNotification />}>
+      <Button {...args} variant="link" icon={<Message />}>
         With Text
       </Button>
     </div>
@@ -186,17 +187,17 @@ export const LoadingStates: Story = {
       </div>
 
       <div className="flex items-center gap-4">
-        <Button {...args} size="xs" icon={<AiFillNotification />} />
-        <Button {...args} size="sm" icon={<AiFillNotification />} />
-        <Button {...args} size="default" icon={<AiFillNotification />} />
-        <Button {...args} size="lg" icon={<AiFillNotification />} />
+        <Button {...args} size="xs" icon={<Message />} />
+        <Button {...args} size="sm" icon={<Message />} />
+        <Button {...args} size="default" icon={<Message />} />
+        <Button {...args} size="lg" icon={<Message />} />
       </div>
 
       <div className="flex items-center gap-4">
-        <Button {...args} size="default" icon={<AiFillNotification />}>
+        <Button {...args} size="default" icon={<Message />}>
           With Text
         </Button>
-        <Button {...args} size="lg" icon={<AiFillNotification />}>
+        <Button {...args} size="lg" icon={<Message />}>
           Large With Text
         </Button>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,7 +1188,6 @@ __metadata:
     prettier: "npm:^3.3.2"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-icons: "npm:^5.5.0"
     rollup-plugin-visualizer: "npm:^6.0.3"
     storybook: "npm:^9.0.13"
     tailwindcss: "npm:^4.1.3"
@@ -6774,15 +6773,6 @@ __metadata:
   peerDependencies:
     react: ^19.1.0
   checksum: 10/c5b58605862c7b0bb044416b01c73647bb8e89717fb5d7a2c279b11815fb7b49b619fe685c404e59f55eb52c66831236cc565c25ee1c2d042739f4a2cc538aa2
-  languageName: node
-  linkType: hard
-
-"react-icons@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "react-icons@npm:5.5.0"
-  peerDependencies:
-    react: "*"
-  checksum: 10/67d5b311c23f74829cb90d58b78ddc87959d2087eda7f29b78d1ab6e337b04b0358a00724d73ab60652469d9a2c66ba3c034b8b7d4f32caae942592f92f59a84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Use `Message` icon to replace `Button` story's icon `AiFillNotification`.
- Remove `react-icons` from `devDependencies`.

Change type:

- 🎨 Refactor

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- `Button` Story runs normally.

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
