### PR TITLE
feat(typewriter): add new component TypeWriter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,4 @@ export * from './tabs';
 export * from './textarea';
 export * from './toast';
 export * from './tooltip';
+export * from './type-writer';

--- a/src/type-writer/index.ts
+++ b/src/type-writer/index.ts
@@ -1,0 +1,1 @@
+export * from './type-writer';

--- a/src/type-writer/type-writer.stories.tsx
+++ b/src/type-writer/type-writer.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '../button';
+
+import { TypeWriter } from './type-writer';
+
+const meta: Meta<typeof TypeWriter> = {
+  title: 'Components/TypeWriter',
+  component: TypeWriter,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'An accessible, dependency-free typewriter effect. Supports multiple strings, speed control, start delay, delete speed, pauses, looping, and customizable cursor.',
+      },
+    },
+  },
+  args: {
+    strings: ['Mints UI', 'Beautifully minimal', 'Typed with TypeScript'],
+    speed: 60,
+    deleteSpeed: 30,
+    startDelay: 0,
+    pauseBetween: 1200,
+    loop: true,
+    cursor: '|',
+    cursorBlink: true,
+  },
+  argTypes: {
+    strings: {
+      control: 'object',
+      description: 'A single string or array of strings to type.',
+    },
+    speed: {
+      control: { type: 'number', min: 0, step: 5 },
+      description: 'Milliseconds per character when typing.',
+    },
+    deleteSpeed: {
+      control: { type: 'number', min: 0, step: 5 },
+      description: 'Milliseconds per character when deleting.',
+    },
+    startDelay: {
+      control: { type: 'number', min: 0, step: 100 },
+      description: 'Delay before typing starts (ms).',
+    },
+    pauseBetween: {
+      control: { type: 'number', min: 0, step: 100 },
+      description: 'Pause after finishing a string (ms).',
+    },
+    loop: {
+      control: 'boolean',
+      description: 'Loop through all strings indefinitely.',
+    },
+    cursor: {
+      control: 'text',
+      description:
+        'Cursor content. Use a string like "|" or "_" for custom, leave empty to hide.',
+    },
+    cursorBlink: {
+      control: 'boolean',
+      description: 'Apply a simple blink animation to the cursor.',
+    },
+    className: { control: false },
+    onCycleEnd: { action: 'cycleEnd' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const MultipleStrings: Story = {
+  args: {
+    strings: ['Build fast.', 'Ship minimal.', 'Polish later.'],
+    loop: true,
+  },
+};
+
+export const CustomCursor: Story = {
+  args: {
+    cursor: '▍',
+    cursorBlink: true,
+  },
+};
+
+export const NoCursor: Story = {
+  args: {
+    cursor: '',
+  },
+};
+
+export const SpeedShowcase: Story = {
+  args: {
+    speed: 30,
+    deleteSpeed: 15,
+    pauseBetween: 600,
+    strings: ['Snappy typing', 'and quicker deletes'],
+  },
+};
+
+export const DelayedStart: Story = {
+  args: {
+    startDelay: 1000,
+    strings: ['Wait for it…', 'Here we go!'],
+  },
+};
+
+export const NoLoopHoldOnFinish: Story = {
+  name: 'No Loop + Hold on Finish',
+  args: {
+    loop: false,
+    strings: ['Type once and hold.'],
+    pauseBetween: 1500,
+    holdOnFinish: 2000,
+  },
+};
+
+export const InAHeading: Story = {
+  render: (args) => (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <h1 className="text-3xl font-bold">
+        <TypeWriter {...args} />
+      </h1>
+      <p className="text-zinc-600 dark:text-zinc-300 max-w-md">
+        Drop this into a hero section to animate your headline without extra
+        dependencies.
+      </p>
+      <div className="flex gap-3">
+        <Button>Get Started</Button>
+        <Button variant="outline">Docs</Button>
+      </div>
+    </div>
+  ),
+  args: {
+    strings: ['Mints UI, but alive.', 'Type. Pause. Delete. Repeat.'],
+    loop: true,
+    speed: 55,
+    deleteSpeed: 28,
+    pauseBetween: 900,
+    cursor: '▌',
+  },
+};

--- a/src/type-writer/type-writer.tsx
+++ b/src/type-writer/type-writer.tsx
@@ -1,0 +1,182 @@
+import clsx from 'clsx';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+type Phase = 'typing' | 'pausing' | 'deleting';
+
+export interface TypeWriterProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  strings: string | string[];
+  speed?: number;
+  deleteSpeed?: number;
+  startDelay?: number;
+  pauseBetween?: number;
+  loop?: boolean;
+  cursor?: boolean | React.ReactNode;
+  cursorBlink?: boolean;
+  holdOnFinish?: number; // ms (default: pauseBetween)
+  onCycleEnd?: () => void;
+}
+
+export function TypeWriter({
+  strings,
+  speed = 60,
+  deleteSpeed,
+  startDelay = 0,
+  pauseBetween = 1200,
+  loop = false,
+  cursor = true,
+  cursorBlink = true,
+  holdOnFinish,
+  className,
+  onCycleEnd,
+  ...props
+}: TypeWriterProps) {
+  const items = useMemo(
+    () =>
+      (Array.isArray(strings) ? strings.filter(Boolean) : [strings]).map(
+        String,
+      ),
+    [strings],
+  );
+
+  const [phase, setPhase] = useState<Phase>('typing');
+  const [strIndex, setStrIndex] = useState(0);
+  const [charIndex, setCharIndex] = useState(0);
+  const [started, setStarted] = useState(startDelay === 0);
+
+  const timerRef = useRef<number | null>(null);
+  const typingSpeed = Math.max(0, speed);
+  const deletingSpeed = Math.max(
+    0,
+    deleteSpeed ?? Math.max(1, Math.floor(speed / 2)),
+  );
+  const doneHold = holdOnFinish ?? pauseBetween;
+
+  const target = items[strIndex] ?? '';
+
+  useEffect(() => {
+    if (started) return;
+    timerRef.current = window.setTimeout(
+      () => setStarted(true),
+      Math.max(0, startDelay),
+    );
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, [startDelay, started]);
+
+  useEffect(() => {
+    if (!started || items.length === 0) return;
+
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+
+    const atEndOfTyping = phase === 'typing' && charIndex === target.length;
+    const atStartOfDeleting = phase === 'deleting' && charIndex === 0;
+
+    if (phase === 'typing') {
+      if (!atEndOfTyping) {
+        timerRef.current = window.setTimeout(() => {
+          setCharIndex((i) => Math.min(target.length, i + 1));
+        }, typingSpeed);
+      } else {
+        timerRef.current = window.setTimeout(() => {
+          if (!loop && items.length === 1) {
+            setPhase('pausing');
+            return;
+          }
+          setPhase(items.length === 1 ? 'pausing' : 'pausing');
+        }, pauseBetween);
+      }
+    } else if (phase === 'pausing') {
+      const isFinalString = !loop && strIndex === items.length - 1;
+      const shouldDelete = loop || items.length > 1;
+
+      timerRef.current = window.setTimeout(
+        () => {
+          if (isFinalString && !shouldDelete) {
+            onCycleEnd?.();
+            return;
+          }
+          if (shouldDelete) {
+            setPhase('deleting');
+          }
+        },
+        isFinalString && !shouldDelete ? doneHold : pauseBetween,
+      );
+    } else if (phase === 'deleting') {
+      if (!atStartOfDeleting) {
+        timerRef.current = window.setTimeout(() => {
+          setCharIndex((i) => Math.max(0, i - 1));
+        }, deletingSpeed);
+      } else {
+        const nextIndex = items.length <= 1 ? 0 : (strIndex + 1) % items.length;
+
+        if (!loop && strIndex === items.length - 1) {
+          setStrIndex(0);
+          setPhase('typing');
+          setCharIndex(0);
+          onCycleEnd?.();
+        } else {
+          setStrIndex(nextIndex);
+          setPhase('typing');
+          setCharIndex(0);
+          if (nextIndex === 0) onCycleEnd?.();
+        }
+      }
+    }
+
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, [
+    started,
+    phase,
+    charIndex,
+    target.length,
+    typingSpeed,
+    deletingSpeed,
+    pauseBetween,
+    doneHold,
+    loop,
+    items.length,
+    strIndex,
+    onCycleEnd,
+  ]);
+
+  const visibleText = started ? target.slice(0, charIndex) : '';
+
+  const srText = target;
+
+  const renderCursor = () => {
+    if (!cursor) return null;
+    if (React.isValidElement(cursor)) return cursor;
+    const symbol = typeof cursor === 'string' ? cursor : '|';
+    return (
+      <span
+        aria-hidden
+        className={clsx(
+          'inline-block select-none dark:text-white',
+          cursorBlink && 'animate-pulse',
+        )}
+      >
+        {symbol}
+      </span>
+    );
+  };
+
+  return (
+    <span
+      className={clsx('inline-flex items-baseline', className)}
+      role="text"
+      {...props}
+    >
+      {/* Screen-reader only: the full semantic text */}
+      <span className="sr-only">{srText}</span>
+      {/* Visual animated text */}
+      <span aria-hidden className="whitespace-pre dark:text-white">
+        {visibleText}
+      </span>
+      {renderCursor()}
+    </span>
+  );
+}


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Character-by-character typing effect with **single/multiple strings**.
- Props: `strings`, `speed`, `deleteSpeed`, `startDelay`, `pauseBetween`, `loop`, `cursor`, `cursorBlink`, `onCycleEnd`
- **Accessible by default**: full text exposed to screen readers (`sr-only`); animated text is `aria-hidden`
- **SSR-safe**: timers only run in effects; static initial render
- **Dark-mode friendly**: inherits text color; no hard-coded colors
- **Zero deps**: only React + clsx
-  Added Storybook stories (Default, MultipleStrings, CustomCursor, NoCursor, SpeedShowcase, DelayedStart, NoLoopHoldOnFinish, InAHeading, DarkModePreview)
- Cursor uses a lightweight blink animation via utility classes; spacing and baseline alignment tuned

Change type:

- ✨ New Component
- 📝 Docs update

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

1. **Default story**: Renders and types `"Mints UI"` sequence; cursor blinks.
2. **Multiple strings**: Cycles through 3 strings with `loop=true`; verify pause between strings and delete speed.
3. **Custom cursor**: Set `cursor="▍"` and `cursorBlink=true`; ensure it replaces default.
4. **No cursor**: `cursor=""` hides cursor entirely.
5. **Speed showcase**: `speed=30`, `deleteSpeed=15`, `pauseBetween=600`; confirm timing differences are visible.
6. **Delayed start**: `startDelay=1000`; ensure typing begins ~1s after mount.
7. **No loop + hold**: `loop=false` with `holdOnFinish` (in story args) pauses on final text without deleting.
8. **Heading integration**: Use inside an `<h1>` with buttons; confirm baseline alignment and no layout shift.
9. **Dark mode preview**: In a dark mode, text and cursor remain legible; inherits color correctly.
10. **Accessibility check**: Using a screen reader (or dev tools), confirm full text is present via sr-only span and animated text is `aria-hidden`.
11. **SSR sanity**: Confirm no warnings on initial render (timers start only in `useEffect`).

## 📎 Related Issues

<!-- Link to related issues or discussions -->

Closes #32 

---

Thanks for your contribution 🙌
