### PR TITLE
feat(input): add xs size support and match corresponding label size

### DIFF
--- a/src/input/input.stories.tsx
+++ b/src/input/input.stories.tsx
@@ -61,6 +61,12 @@ export const WithError: Story = {
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex flex-col gap-4">
+      <Input
+        {...args}
+        size="xs"
+        label="Extra Samll"
+        placeholder="Extra Samll"
+      />
       <Input {...args} size="sm" label="Small" placeholder="Small size" />
       <Input
         {...args}

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
 
-export type InputSize = 'sm' | 'default' | 'lg';
+export type InputSize = 'xs' | 'sm' | 'default' | 'lg';
 
 type NativeInputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -15,7 +15,15 @@ export interface InputProps extends NativeInputProps {
   inputClassName?: string;
 }
 
+const labelSizeClass = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  default: 'text-base',
+  lg: 'text-lg',
+};
+
 const sizeClass = {
+  xs: 'text-xs px-2 py-1 rounded-md',
   sm: 'text-sm px-3 py-1.5 rounded-md',
   default: 'text-base px-4 py-2 rounded-md',
   lg: 'text-lg px-5 py-2.5 rounded-md',
@@ -37,7 +45,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={clsx('flex flex-col gap-1', className)}>
         {label && (
-          <label className="text-sm font-medium text-zinc-900 dark:text-white flex items-center gap-1">
+          <label
+            className={clsx(
+              'font-medium text-zinc-900 dark:text-white flex items-center gap-1',
+              labelSizeClass[size],
+            )}
+          >
             {label}
             {required && (
               <span className="text-red-500" aria-label="required">


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Added support for `xs` size prop in the Input component
- Updated `labelSizeClass` mapping so label size now matches the Input size (previously, label size was fixed for all input sizes)

#### Change type:

- 🎨 Style polish

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified `xs` size rendering in Storybook for Input component
- Confirmed label size now adjusts according to Input size (`xs`, `sm`, `default`, `lg`)
- Checked that other existing sizes remain visually correct and unaffected except for intended label size adjustments

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
