### PR TITLE
feat(textarea): add xs size support and match corresponding label size

### DIFF
--- a/src/textarea/textarea.stories.tsx
+++ b/src/textarea/textarea.stories.tsx
@@ -46,6 +46,7 @@ export const WithError: Story = {
 export const Sizes: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-full max-w-md">
+      <TextArea label="Extra Small" placeholder="Extra Small" size="xs" />
       <TextArea label="Small" placeholder="Small size" size="sm" />
       <TextArea label="Default" placeholder="Default size" />
       <TextArea label="Large" placeholder="Large size" size="lg" />

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
 
-export type TextAreaSize = 'sm' | 'default' | 'lg';
+export type TextAreaSize = 'xs' | 'sm' | 'default' | 'lg';
 export type TextAreaResize = 'none' | 'both' | 'x' | 'y';
 
 type NativeTextAreaProps = Omit<
@@ -17,7 +17,15 @@ export interface TextAreaProps extends NativeTextAreaProps {
   textareClassName?: string;
 }
 
+const labelSizeClass = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  default: 'text-base',
+  lg: 'text-lg',
+};
+
 const sizeClass = {
+  xs: 'text-xs px-2 py-1 rounded-md',
   sm: 'text-sm px-3 py-1.5 rounded-md',
   default: 'text-base px-4 py-2 rounded-md',
   lg: 'text-lg px-5 py-2.5 rounded-md',
@@ -47,7 +55,12 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <div className={clsx('flex flex-col gap-1', className)}>
         {label && (
-          <label className="text-sm font-medium text-zinc-900 dark:text-white flex items-center gap-1">
+          <label
+            className={clsx(
+              'font-medium text-zinc-900 dark:text-white flex items-center gap-1',
+              labelSizeClass[size],
+            )}
+          >
             {label}
             {required && (
               <span className="text-red-500" aria-label="required">


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Added support for `xs` size prop in the TextArea component
- Updated `labelSizeClass` mapping so label size now matches the textarea size (previously, label size was fixed for all textarea sizes)

#### Change type:

- 🎨 Style polish

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified `xs` size rendering in Storybook for TextArea component
- Confirmed label size now adjusts according to TextArea size (`xs`, `sm`, `default`, `lg`)
- Checked that other existing sizes remain visually correct and unaffected except for intended label size adjustments

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
