### PR TITLE
fix(input): set default type to text

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -38,6 +38,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       className,
       inputClassName,
       required,
+      type = 'text',
       ...props
     },
     ref,
@@ -70,6 +71,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             sizeClass[size],
             inputClassName,
           )}
+          type={type}
           {...props}
         />
         {error && <p className="text-sm text-red-500">{error}</p>}


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Set a default `type="text"` for the `Input` component.
Previously, if `type` was not explicitly provided, the underlying `<input>` element’s type would be `undefined`, relying on the browser’s default. This change ensures consistent behavior and prevents unintended type defaults.

#### Change type:

- 🐛 Bugfix

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Rendered `Input` without specifying `type` and verified that the resulting HTML `<input>` has `type="text"`.
- Verified that explicitly passing `type` (e.g., `"password"`, `"number"`) overrides the default as expected.
- Checked visual rendering in Storybook for multiple `Input` use cases.

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
