### PR TITLE
fix(autocomplete): clear button style error

### DIFF
--- a/src/auto-complete/auto-complete.tsx
+++ b/src/auto-complete/auto-complete.tsx
@@ -155,13 +155,14 @@ export function AutoComplete({
         {inputNode}
         {showClear && (
           <Button
-            icon={<Close className="text-zinc-300" />}
+            icon={<Close />}
+            size="sm"
             variant="link"
             type="button"
             onClick={handleClear}
             aria-label="Clear"
             tabIndex={-1}
-            className="absolute right-3 top-1/2 -translate-y-1/2 z-10 p-1 rounded-full text-zinc-400 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-700 dark:hover:text-zinc-100"
+            className="absolute right-3 top-1/2 -translate-y-1/2 z-10"
           />
         )}
       </div>


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

This PR fixes the positioning and sizing of the `Autocomplete` clear button when `allowClear` is enabled.

- **Implementation change**: Remove extra style for `Button` component.
- **Result**:
  - Clear button now sits fully inside the input field’s bounds.
  - Hit area is correctly constrained to the icon size and input height.
  - Dropdown options beneath the button remain clickable without interference.

Change type:

- 🐛 Bugfix

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook and with the provided reproduction snippet.
- Typed into the `Autocomplete` to open the dropdown, confirmed:
  - No gray square or background leakage.
  - Clicks on dropdown options in the top-right area work as expected.

## 📎 Related Issues

<!-- Link to related issues or discussions -->

Closes #40 

---

Thanks for your contribution 🙌
