### PR TITLE
feat(icons): add new icons eye and eye-closed

### DIFF
--- a/src/icons/eye-closed.tsx
+++ b/src/icons/eye-closed.tsx
@@ -1,0 +1,26 @@
+export function EyeClosed({
+  size = 24,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="m15 18-.722-3.25" />
+      <path d="M2 8a10.645 10.645 0 0 0 20 0" />
+      <path d="m20 15-1.726-2.05" />
+      <path d="m4 15 1.726-2.05" />
+      <path d="m9 18 .722-3.25" />
+    </svg>
+  );
+}

--- a/src/icons/eye.tsx
+++ b/src/icons/eye.tsx
@@ -1,0 +1,23 @@
+export function Eye({
+  size = 24,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/src/icons/icons.stories.tsx
+++ b/src/icons/icons.stories.tsx
@@ -13,6 +13,8 @@ import {
   CircleClose,
   Close,
   Ellipsis,
+  EyeClosed,
+  Eye,
   Info,
   Layers,
   Message,
@@ -73,6 +75,14 @@ const icons = [
   {
     component: <Ellipsis />,
     label: 'Ellipsis',
+  },
+  {
+    component: <EyeClosed />,
+    label: 'EyeClosed',
+  },
+  {
+    component: <Eye />,
+    label: 'Eye',
   },
   {
     component: <Info />,

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -9,6 +9,8 @@ export { CircleCheck } from './circle-check';
 export { CircleClose } from './circle-close';
 export { Close } from './close';
 export { Ellipsis } from './ellipsis';
+export { EyeClosed } from './eye-closed';
+export { Eye } from './eye';
 export { Info } from './info';
 export { Message } from './message';
 export { Layers } from './layers';


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Added two new icons to the icon library:
- `Eye`
- `EyeClosed`

This enables usage for visibility toggle features and other UI patterns requiring open/closed eye states.

#### Change type:

- ✨ New Component

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

Tested manually by:

- Rendering `Eye` and `EyeClosed` in Storybook
- Verifying correct SVG paths render and scale properly at different sizes
- Checking icon color inheritance and responsiveness to theme changes

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
