### PR TITLE
fix(button): adjust the icon only button size

### DIFF
--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -121,7 +121,10 @@ export const DangerStates: Story = {
 export const WithIcon: Story = {
   render: (args) => (
     <div className="flex flex-wrap gap-4 items-center">
+      <Button {...args} size="xs" icon={<Message />} />
+      <Button {...args} size="sm" icon={<Message />} />
       <Button {...args} icon={<Message />} />
+      <Button {...args} size="lg" icon={<Message />} />
       <Button {...args} variant="outline" icon={<Message />} />
       <Button {...args} variant="link" icon={<Message />} />
       <Button {...args} icon={<Message />}>

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -64,12 +64,21 @@ export function Button({
     ),
   }[variant];
 
-  const sizeClass = {
-    xs: 'text-xs px-2 py-1',
-    sm: 'text-sm px-3 py-1.5',
-    default: 'text-base px-4 py-2',
-    lg: 'text-lg px-5 py-2.5',
-  }[size];
+  const isIconOnly = !children && (icon || loading);
+
+  const sizeClass = isIconOnly
+    ? {
+        xs: 'px-1 py-1',
+        sm: 'px-1.5 py-1.5',
+        default: 'px-2 py-2',
+        lg: 'px-2.5 py-2.5',
+      }[size]
+    : {
+        xs: 'text-xs px-2 py-1',
+        sm: 'text-sm px-3 py-1.5',
+        default: 'text-base px-4 py-2',
+        lg: 'text-lg px-5 py-2.5',
+      }[size];
 
   const iconSize = {
     xs: 16,


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

- Fix icon-only button sizing.
- Storybook examples updated to showcase icon buttons across sizes (`xs`, `sm`, `default`, `lg`) so visual regressions are easier to spot.

This resolves inconsistent visual density and misalignment for icon-only buttons, which previously inherited text classes and overly wide horizontal padding.

#### Change type:

- 🐛 Bugfix

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

- Verified in Storybook:
  - All sizes render correctly for icon-only buttons (square-ish shape, expected padding).
  - Non–icon-only buttons continue to use the original text classes and spacing.
- Checked hover/focus/disabled/loading states to ensure sizing remains stable.
- Snapshot/visual regression pass on updated stories (icon-only across sizes).

## 📎 Related Issues

<!-- Link to related issues or discussions -->

N/A

---

Thanks for your contribution 🙌
