### PR TITLE
feat(pagination): add new component Pagination

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from './dropdown';
 export * from './icons';
 export * from './input';
 export * from './mask';
+export * from './pagination';
 export * from './pop-confirm';
 export * from './progress';
 export * from './radio';

--- a/src/pagination/index.ts
+++ b/src/pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './pagination';

--- a/src/pagination/pagination.stories.tsx
+++ b/src/pagination/pagination.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Pagination } from './pagination';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A pagination component for navigating through large datasets with support for page size selection, quick jumping, and total count display.',
+      },
+    },
+  },
+  args: {
+    current: 1,
+    total: 100,
+    size: 'default',
+    disabled: false,
+    showSizeChanger: false,
+    showQuickJumper: false,
+    showTotal: false,
+    pageSize: 10,
+  },
+  argTypes: {
+    current: { control: { type: 'number', min: 1 } },
+    total: { control: { type: 'number', min: 0 } },
+    pageSize: { control: { type: 'number', min: 1 } },
+    size: {
+      control: 'radio',
+      options: ['sm', 'default', 'lg'],
+    },
+    disabled: { control: 'boolean' },
+    showSizeChanger: { control: 'boolean' },
+    showQuickJumper: { control: 'boolean' },
+    showTotal: { control: 'boolean' },
+    onChange: { action: 'page changed' },
+    onShowSizeChange: { action: 'page size changed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    current: 5,
+    total: 200,
+  },
+};
+
+export const WithInteractiveState: Story = {
+  render: () => {
+    const [current, setCurrent] = useState(5);
+    const [pageSize, setPageSize] = useState(10);
+    const total = 247;
+
+    const handleChange = (page: number, newPageSize?: number) => {
+      setCurrent(page);
+      if (newPageSize && newPageSize !== pageSize) {
+        setPageSize(newPageSize);
+      }
+    };
+
+    const handleShowSizeChange = (page: number, size: number) => {
+      setCurrent(page);
+      setPageSize(size);
+    };
+
+    const totalPages = Math.ceil(total / pageSize);
+
+    return (
+      <div className="space-y-4">
+        <div className="text-sm text-zinc-600">
+          Interactive pagination - try clicking pages, changing size, or using
+          quick jump
+        </div>
+        <Pagination
+          size="sm"
+          current={current}
+          total={total}
+          pageSize={pageSize}
+          showSizeChanger
+          showQuickJumper
+          showTotal
+          onChange={handleChange}
+          onShowSizeChange={handleShowSizeChange}
+        />
+        <div className="text-xs text-zinc-500">
+          Current page: {current}, Page size: {pageSize}, Total pages:{' '}
+          {totalPages}, Total items: {total}
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium mb-2">Small</h3>
+        <Pagination {...args} size="sm" />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">Default</h3>
+        <Pagination {...args} size="default" />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">Large</h3>
+        <Pagination {...args} size="lg" />
+      </div>
+    </div>
+  ),
+  args: {
+    current: 3,
+    total: 100,
+  },
+};
+
+export const DifferentPageCounts: Story = {
+  render: (args) => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium mb-2">Few items (50 total)</h3>
+        <Pagination {...args} current={3} total={50} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">
+          Many items (500 total, current page 25)
+        </h3>
+        <Pagination {...args} current={25} total={500} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">
+          Beginning (current page 2 of 200 items)
+        </h3>
+        <Pagination {...args} current={2} total={200} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">
+          End (current page 19 of 200 items)
+        </h3>
+        <Pagination {...args} current={19} total={200} />
+      </div>
+    </div>
+  ),
+};
+
+export const WithAllFeatures: Story = {
+  args: {
+    current: 8,
+    total: 485,
+    pageSize: 20,
+    showSizeChanger: true,
+    showQuickJumper: true,
+    showTotal: true,
+    pageSizeOptions: [10, 20, 50, 100],
+  },
+};
+
+export const WithCustomTotal: Story = {
+  args: {
+    current: 3,
+    total: 367,
+    pageSize: 25,
+    showTotal: (total, range) => (
+      <span className="text-sm font-medium text-blue-600">
+        Items {range[0]}-{range[1]} of {total} total
+      </span>
+    ),
+  },
+};
+
+export const DisabledState: Story = {
+  args: {
+    current: 5,
+    total: 200,
+    disabled: true,
+    showSizeChanger: true,
+    showQuickJumper: true,
+    showTotal: true,
+  },
+};
+
+export const EdgeCases: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium mb-2">Single item</h3>
+        <Pagination current={1} total={1} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">First page of many items</h3>
+        <Pagination current={1} total={1000} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">Last page of many items</h3>
+        <Pagination current={100} total={1000} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">Empty state (0 items)</h3>
+        <Pagination current={1} total={0} showTotal showSizeChanger />
+      </div>
+    </div>
+  ),
+};

--- a/src/pagination/pagination.tsx
+++ b/src/pagination/pagination.tsx
@@ -1,0 +1,207 @@
+import clsx from 'clsx';
+
+import { Button } from '../button';
+import { ChevronLeft, ChevronRight, Ellipsis } from '../icons';
+import { Input } from '../input';
+import { Select } from '../select';
+
+export type PaginationSize = 'sm' | 'default' | 'lg';
+
+export interface PaginationProps {
+  current: number;
+  total: number;
+  showSizeChanger?: boolean;
+  pageSizeOptions?: number[];
+  pageSize?: number;
+  size?: PaginationSize;
+  disabled?: boolean;
+  showQuickJumper?: boolean;
+  showTotal?:
+    | boolean
+    | ((total: number, range: [number, number]) => React.ReactNode);
+  onChange?: (page: number, pageSize?: number) => void;
+  onShowSizeChange?: (current: number, size: number) => void;
+  className?: string;
+}
+
+function getVisiblePages(
+  current: number,
+  total: number,
+): (number | 'ellipsis')[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+
+  const pages: (number | 'ellipsis')[] = [1];
+
+  if (current <= 4) {
+    pages.push(2, 3, 4, 5, 'ellipsis', total);
+  } else if (current >= total - 3) {
+    pages.push('ellipsis', total - 4, total - 3, total - 2, total - 1, total);
+  } else {
+    pages.push(
+      'ellipsis',
+      current - 1,
+      current,
+      current + 1,
+      'ellipsis',
+      total,
+    );
+  }
+
+  return pages;
+}
+
+export function Pagination({
+  current = 1,
+  total = 0,
+  showSizeChanger = false,
+  pageSizeOptions = [10, 20, 50, 100],
+  pageSize = 10,
+  size = 'default',
+  disabled = false,
+  showQuickJumper = false,
+  showTotal = false,
+  onChange,
+  onShowSizeChange,
+  className,
+}: PaginationProps) {
+  const totalPages = Math.ceil(total / pageSize) || 1;
+  const visiblePages = getVisiblePages(current, totalPages);
+
+  const handlePageChange = (page: number) => {
+    if (disabled || page < 1 || page > totalPages || page === current) return;
+    onChange?.(page, pageSize);
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    if (disabled) return;
+    const newPage = Math.min(current, Math.ceil(total / newSize));
+    onShowSizeChange?.(newPage, newSize);
+    onChange?.(newPage, newSize);
+  };
+
+  const handleQuickJump = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      const page = parseInt((e.target as HTMLInputElement).value);
+      if (!isNaN(page) && page >= 1 && page <= totalPages) {
+        handlePageChange(page);
+        (e.target as HTMLInputElement).value = '';
+      }
+    }
+  };
+
+  const renderTotal = () => {
+    if (!showTotal || !total) return null;
+
+    const start = (current - 1) * pageSize + 1;
+    const end = Math.min(current * pageSize, total);
+
+    if (typeof showTotal === 'function') {
+      return showTotal(total, [start, end]);
+    }
+
+    return (
+      <span className="text-sm text-zinc-600 dark:text-zinc-400">
+        Showing {start}-{end} of {total} items
+      </span>
+    );
+  };
+
+  const buttonSize = size === 'sm' ? 'xs' : size === 'lg' ? 'default' : 'sm';
+  const inputSize = size === 'sm' ? 'xs' : size === 'lg' ? 'default' : 'sm';
+
+  return (
+    <div className={clsx('flex items-center justify-between gap-4', className)}>
+      <div className="flex items-center gap-4">
+        {renderTotal()}
+
+        {showSizeChanger && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-zinc-600 dark:text-zinc-400">
+              Show
+            </span>
+            <Select
+              options={pageSizeOptions.map((option) => ({
+                label: option,
+                value: option,
+              }))}
+              value={pageSize}
+              onChange={(value) => handlePageSizeChange(value as number)}
+              disabled={disabled}
+              size={inputSize}
+            />
+            <span className="text-sm text-zinc-600 dark:text-zinc-400">
+              per page
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size={buttonSize}
+          icon={<ChevronLeft size={30} />}
+          disabled={disabled || current <= 1}
+          onClick={() => handlePageChange(current - 1)}
+          aria-label="Previous page"
+        />
+
+        {visiblePages.map((page, index) => {
+          if (page === 'ellipsis') {
+            return (
+              <div
+                key={`ellipsis-${index}`}
+                className="flex items-center justify-center w-8 h-8 text-zinc-400"
+              >
+                <Ellipsis className="w-4 h-4" />
+              </div>
+            );
+          }
+
+          return (
+            <Button
+              key={page}
+              variant={page === current ? 'primary' : 'outline'}
+              size={buttonSize}
+              disabled={disabled}
+              onClick={() => handlePageChange(page)}
+              aria-label={`Page ${page}`}
+              aria-current={page === current ? 'page' : undefined}
+            >
+              {page}
+            </Button>
+          );
+        })}
+
+        <Button
+          variant="outline"
+          size={buttonSize}
+          icon={<ChevronRight />}
+          disabled={disabled || current >= totalPages}
+          onClick={() => handlePageChange(current + 1)}
+          aria-label="Next page"
+        />
+
+        {showQuickJumper && (
+          <div className="flex items-center gap-2 ml-4">
+            <span className="text-sm text-zinc-600 dark:text-zinc-400">
+              Go to
+            </span>
+            <Input
+              type="number"
+              min={1}
+              max={totalPages}
+              disabled={disabled}
+              onKeyDown={handleQuickJump}
+              placeholder="..."
+              size={inputSize}
+              className="w-16"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## ✨ What’s Changed

<!-- Describe what this PR changes, adds, or fixes -->

Introduce a new Pagination component.
  - Controlled API with `current`, `total`, and `pageSize`
  - Smart ellipsis logic for large datasets
  - Optional `showSizeChanger` with `pageSizeOptions`
  - Optional `showQuickJumper` with Enter-to-jump
  - Optional `showTotal` (boolean or render function)
  - Size variants: `sm` / `default` / `lg`
  - Disabled state support
  - Accessible labels and `aria-current` for active pages
  - Dark mode–friendly text styles

**Change type:**

- ✨ New Component

---

## 🧪 Test Plan

<!-- Describe how you tested your changes manually or with Storybook -->

Manually tested with Storybook:

1. **Default**: `total=120, current=1, pageSize=10`
2. **Few Pages (<=7)**: no ellipsis rendered
3. **Many Pages (>7)**: ellipsis shows correctly at edges and middle
4. **Size Variants**: `sm`, `default`, `lg`
5. **Size Changer**: switching page size updates correctly
6. **Quick Jumper**: typing valid/invalid values, pressing Enter
7. **Show Total**: both boolean and function modes
8. **Disabled State**: all interactions disabled
9. **Boundary Controls**: prev/next disabled at page edges
10. **Dark Mode**: ensure readable text contrast

## 📎 Related Issues

<!-- Link to related issues or discussions -->

Closes #26 

---

Thanks for your contribution 🙌
